### PR TITLE
Install wxPython and make the ELF executable

### DIFF
--- a/.github/workflows/build_linux_elf.yml
+++ b/.github/workflows/build_linux_elf.yml
@@ -18,7 +18,8 @@ jobs:
       run: python -m pip install --find-links ${URL} wxPython
     - run: python setup.py clean bundle
     - run: chmod +x /home/runner/work/PythonTurtle/PythonTurtle/dist/PythonTurtle
+    - run: tar -cvf PythonTurtle_for_Linux.tar /home/runner/work/PythonTurtle/PythonTurtle/dist/PythonTurtle
     - uses: actions/upload-artifact@v2
       with:
         name: PythonTurtle for Linux
-        path: /home/runner/work/PythonTurtle/PythonTurtle/dist/PythonTurtle
+        path: PythonTurtle_for_Linux.tar

--- a/.github/workflows/build_linux_elf.yml
+++ b/.github/workflows/build_linux_elf.yml
@@ -18,7 +18,7 @@ jobs:
       run: python -m pip install --find-links ${URL} wxPython
     - run: python setup.py clean bundle
     - run: chmod +x /home/runner/work/PythonTurtle/PythonTurtle/dist/PythonTurtle
-    - run: tar -cvf PythonTurtle_for_Linux.tar /home/runner/work/PythonTurtle/PythonTurtle/dist/PythonTurtle
+    - run: tar -cfvz PythonTurtle_for_Linux.tgz /home/runner/work/PythonTurtle/PythonTurtle/dist/PythonTurtle
     - uses: actions/upload-artifact@v2
       with:
         name: PythonTurtle for Linux

--- a/.github/workflows/build_linux_elf.yml
+++ b/.github/workflows/build_linux_elf.yml
@@ -13,7 +13,11 @@ jobs:
     - uses: actions/setup-python@v2
     - run: sudo apt-get install libsdl2-2.0-0
     - run: python -m pip install pyinstaller
+    - env:
+        URL: https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04
+      run: python -m pip install --find-links ${URL} wxPython
     - run: python setup.py clean bundle
+    - run: chmod +x /home/runner/work/PythonTurtle/PythonTurtle/dist/PythonTurtle
     - uses: actions/upload-artifact@v2
       with:
         name: PythonTurtle for Linux


### PR DESCRIPTION
This pull request pip installs wxPython before pyinstaller creates the Linux ELF file.
It also sets the execution permission on the ELF file so that it can be run.