### PR TITLE
pip install wxPython before building the Windows EXE

### DIFF
--- a/.github/workflows/build_windows_exe.yml
+++ b/.github/workflows/build_windows_exe.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - run: python -m pip install pyinstaller
+    - run: python -m pip install pyinstaller wxPython
     - run: python setup.py clean bundle
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
This pull request pip installs wxPython before pyinstaller creates the Windows EXE file.